### PR TITLE
add yaml subtree folding

### DIFF
--- a/emacs-cheat-sheet.org
+++ b/emacs-cheat-sheet.org
@@ -53,9 +53,10 @@
    5. =C-c C-e= apply edits to file buffers.
    6. Review and save explicitly, e.g. =C-x s=.
 
-** YAML folding
+** YAML and Python folding
 
-   =outline-indent-minor-mode= is enabled in =yaml-mode= and =yaml-ts-mode=.
+   =outline-indent-minor-mode= is enabled in =yaml-mode=, =yaml-ts-mode=,
+   =python-mode=, and =python-ts-mode=.
 
    | key     | command                    |
    |---------+----------------------------|

--- a/emacs-cheat-sheet.org
+++ b/emacs-cheat-sheet.org
@@ -53,6 +53,20 @@
    5. =C-c C-e= apply edits to file buffers.
    6. Review and save explicitly, e.g. =C-x s=.
 
+** YAML folding
+
+   =outline-indent-minor-mode= is enabled in =yaml-mode= and =yaml-ts-mode=.
+
+   | key     | command                    |
+   |---------+----------------------------|
+   | C-c o t | toggle fold at point       |
+   | C-c o c | close fold at point        |
+   | C-c o o | open fold at point         |
+   | C-c o m | close all folds            |
+   | C-c o r | open all folds             |
+
+   Bare =TAB= still indents with =indent-for-tab-command=.
+
 ** Avy  (jump to visible text)
 
    | key | command             |

--- a/init.el
+++ b/init.el
@@ -845,7 +845,7 @@ MCP Parameters:
 
 (use-package outline-indent
   :hook
-  ((yaml-mode yaml-ts-mode) . outline-indent-minor-mode)
+  ((yaml-mode yaml-ts-mode python-mode python-ts-mode) . outline-indent-minor-mode)
   :bind
   (:map outline-indent-minor-mode-map
         ("C-c o t" . outline-indent-toggle-fold)

--- a/init.el
+++ b/init.el
@@ -843,6 +843,17 @@ MCP Parameters:
 (use-package yaml-mode
   :mode ("\\.ya?ml\\'" . yaml-mode))
 
+(use-package outline-indent
+  :hook
+  ((yaml-mode yaml-ts-mode) . outline-indent-minor-mode)
+  :bind
+  (:map outline-indent-minor-mode-map
+        ("C-c o t" . outline-indent-toggle-fold)
+        ("C-c o c" . outline-indent-close-fold)
+        ("C-c o o" . outline-indent-open-fold)
+        ("C-c o m" . outline-indent-close-folds)
+        ("C-c o r" . outline-indent-open-folds)))
+
 (use-package jsonnet-mode)
 
 (use-package go-mode

--- a/jeff-emacs-config.org
+++ b/jeff-emacs-config.org
@@ -1509,10 +1509,16 @@
 #+begin_src emacs-lisp
   (use-package yaml-mode
     :mode ("\\.ya?ml\\'" . yaml-mode))
+#+end_src
 
+** outline-indent
+
+   =outline-indent= provides subtree folding for indentation-structured modes.
+
+#+begin_src emacs-lisp
   (use-package outline-indent
     :hook
-    ((yaml-mode yaml-ts-mode) . outline-indent-minor-mode)
+    ((yaml-mode yaml-ts-mode python-mode python-ts-mode) . outline-indent-minor-mode)
     :bind
     (:map outline-indent-minor-mode-map
           ("C-c o t" . outline-indent-toggle-fold)

--- a/jeff-emacs-config.org
+++ b/jeff-emacs-config.org
@@ -1509,6 +1509,17 @@
 #+begin_src emacs-lisp
   (use-package yaml-mode
     :mode ("\\.ya?ml\\'" . yaml-mode))
+
+  (use-package outline-indent
+    :hook
+    ((yaml-mode yaml-ts-mode) . outline-indent-minor-mode)
+    :bind
+    (:map outline-indent-minor-mode-map
+          ("C-c o t" . outline-indent-toggle-fold)
+          ("C-c o c" . outline-indent-close-fold)
+          ("C-c o o" . outline-indent-open-fold)
+          ("C-c o m" . outline-indent-close-folds)
+          ("C-c o r" . outline-indent-open-folds)))
 #+end_src
 
 ** jsonnet


### PR DESCRIPTION
## Summary
- enable outline-indent folding in yaml-mode and yaml-ts-mode
- bind YAML-local C-c o folding commands without taking over TAB
- document the new YAML folding keys in the cheat sheet

## Test
- /usr/bin/env PATH=/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/bin/just verify-tangle
- batch checked yaml-ts-mode and yaml-mode hooks/keybindings during implementation