### PR TITLE
add llm-assisted python rewriting

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,34 @@
+# V1 LLM-assisted Python buffer editing
+
+## Goal
+
+Add a review-first `gptel-rewrite` workflow for selected regions in Python
+buffers, using the existing `gptel` backends and current Python tooling.
+
+## Why
+
+This is the first implementation slice from the AI / LLM integration work:
+`gptel` chat already exists, but code editing in live buffers should start with
+a small, explicit, reviewable command before broader project-editing agents or
+inline completion.
+
+## Approach
+
+- Configure `gptel-rewrite` from the existing `gptel` package.
+- Bind `C-c g r` for region rewrite.
+- Keep rewrite results review-first by leaving `gptel-rewrite-default-action`
+  nil.
+- Add a Python-specific rewrite directive for `python-mode` and
+  `python-ts-mode`.
+- Add `gptel-context` bindings for adding and clearing optional context.
+- Document the new keys in `emacs-cheat-sheet.org`.
+
+## Verification
+
+- Run `just verify-tangle`.
+- Confirm `init.el` contains the generated `gptel-rewrite` and
+  `gptel-context` blocks.
+- In live Emacs, test `C-h f gptel-rewrite` and
+  `C-h v gptel-rewrite-default-action`.
+- In a Python buffer, select a function, run `C-c g r`, inspect diff/ediff,
+  accept the rewrite, save, and confirm Ruff/Eglot behavior remains normal.

--- a/emacs-cheat-sheet.org
+++ b/emacs-cheat-sheet.org
@@ -145,6 +145,9 @@
    | C-c g g | start or switch to a gptel chat buffer |
    | C-c g s | send region/buffer text to gptel       |
    | C-c g m | open the gptel transient menu          |
+   | C-c g r | rewrite selected region with review    |
+   | C-c g a | add selected/current context           |
+   | C-c g A | clear gptel context                    |
 
 ** Eshell
 

--- a/init.el
+++ b/init.el
@@ -752,6 +752,38 @@ In effect, adjusts the pixel size of the frame font up or down by the prefix val
   (with-eval-after-load 'which-key
     (which-key-add-key-based-replacements "C-c g" "gptel")))
 
+(use-package gptel-rewrite
+  :ensure nil  ; ships with gptel
+  :commands (gptel-rewrite)
+  :bind (("C-c g r" . gptel-rewrite))
+  :custom
+  (gptel-rewrite-default-action nil)
+  :config
+  (defun jwm/gptel-python-rewrite-directive ()
+    "Return a Python-specific directive for `gptel-rewrite'."
+    (when (derived-mode-p 'python-mode 'python-ts-mode)
+      (concat
+       "You are editing Python code in an Emacs buffer. "
+       "Make the smallest focused change that satisfies the request. "
+       "Preserve behavior unless the user explicitly asks for a behavior change. "
+       "Do not introduce new dependencies unless the user asks for them. "
+       "Return only the replacement code for the selected region.")))
+
+  (add-hook 'gptel-rewrite-directives-hook
+            #'jwm/gptel-python-rewrite-directive))
+
+(use-package gptel-context
+  :ensure nil  ; ships with gptel
+  :commands (gptel-context-add gptel-context-remove-all)
+  :bind (("C-c g a" . gptel-context-add)
+         ("C-c g A" . gptel-context-remove-all))
+  :config
+  (with-eval-after-load 'which-key
+    (which-key-add-key-based-replacements
+      "C-c g a" "add gptel context"
+      "C-c g A" "clear gptel context"
+      "C-c g r" "rewrite region")))
+
 (use-package mcp-server-lib
   :commands (mcp-server-lib-install
              mcp-server-lib-uninstall

--- a/jeff-emacs-config.org
+++ b/jeff-emacs-config.org
@@ -1450,6 +1450,63 @@
          (which-key-add-key-based-replacements "C-c g" "gptel")))
    #+END_SRC
 
+** gptel rewrite
+
+   =gptel-rewrite= rewrites, refactors, or fills in the active
+   region using the current =gptel= backend.  This is the first
+   code-editing workflow: select code, request a change, then review
+   the proposed rewrite before accepting it.  Keeping
+   =gptel-rewrite-default-action= nil makes the review step explicit;
+   generated code is not accepted into the buffer automatically.
+
+   Python buffers get a small directive that biases the model toward
+   surgical edits that preserve behavior unless the prompt asks for a
+   behavior change.
+
+   #+BEGIN_SRC emacs-lisp
+     (use-package gptel-rewrite
+       :ensure nil  ; ships with gptel
+       :commands (gptel-rewrite)
+       :bind (("C-c g r" . gptel-rewrite))
+       :custom
+       (gptel-rewrite-default-action nil)
+       :config
+       (defun jwm/gptel-python-rewrite-directive ()
+         "Return a Python-specific directive for `gptel-rewrite'."
+         (when (derived-mode-p 'python-mode 'python-ts-mode)
+           (concat
+            "You are editing Python code in an Emacs buffer. "
+            "Make the smallest focused change that satisfies the request. "
+            "Preserve behavior unless the user explicitly asks for a behavior change. "
+            "Do not introduce new dependencies unless the user asks for them. "
+            "Return only the replacement code for the selected region.")))
+
+       (add-hook 'gptel-rewrite-directives-hook
+                 #'jwm/gptel-python-rewrite-directive))
+   #+END_SRC
+
+** gptel context
+
+   =gptel-context-add= adds the active region, current buffer, or
+   context-at-point to the next request.  It is optional and explicit:
+   use it when the rewrite needs surrounding code or another buffer,
+   then clear it when the extra context should not leak into the next
+   prompt.
+
+   #+BEGIN_SRC emacs-lisp
+     (use-package gptel-context
+       :ensure nil  ; ships with gptel
+       :commands (gptel-context-add gptel-context-remove-all)
+       :bind (("C-c g a" . gptel-context-add)
+              ("C-c g A" . gptel-context-remove-all))
+       :config
+       (with-eval-after-load 'which-key
+         (which-key-add-key-based-replacements
+           "C-c g a" "add gptel context"
+           "C-c g A" "clear gptel context"
+           "C-c g r" "rewrite region")))
+   #+END_SRC
+
 ** Emacs MCP read-only introspection
 
    This is the first tiny spike for letting an external process ask


### PR DESCRIPTION
## Summary
- add review-first gptel-rewrite support for selected code regions
- add Python-specific rewrite guidance for small, behavior-preserving edits
- add gptel context add/clear bindings and cheat-sheet entries

## Verification
- /opt/homebrew/bin/just verify-tangle
- batch key check: C-c g r/a/A resolve to gptel-rewrite, gptel-context-add, and gptel-context-remove-all
- batch config check: gptel-rewrite-default-action is nil and jwm/gptel-python-rewrite-directive is loaded

## Notes
- No external agent process is started by this change.
- Batch Emacs reported sandbox-only recentf/history write warnings while the config load itself passed.