### PR TITLE
add agent issue workflow

### DIFF
--- a/.github/workflows/agent-label-lifecycle.yml
+++ b/.github/workflows/agent-label-lifecycle.yml
@@ -1,0 +1,30 @@
+name: agent-label-lifecycle
+
+# The `agent:*` axis is the workflow-state pointer: what happens next and who
+# owns it. A closed issue has no next action, so it must carry zero `agent:*`
+# labels. This runs on every close path, including PR auto-close, manual close,
+# and `gh issue close`.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  strip-agent-state:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove agent:* labels on close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue view "$ISSUE" --repo "$REPO" --json labels \
+            --jq '.labels[].name | select(startswith("agent:"))' \
+          | while read -r label; do
+              echo "Removing $label from #$ISSUE"
+              gh issue edit "$ISSUE" --repo "$REPO" --remove-label "$label"
+            done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,19 @@ The loop:
 
 If a `TASK.md` file exists in the repo root (or a feature worktree's root), read it before starting any work. It describes what's currently being worked on — the goal, approach, and relevant notes. It is branch-tracked and should be removed before the branch is merged, so it never reaches `main`.
 
+## GitHub issue workflow
+
+When work starts from a GitHub issue, honor the `agent:*` label as the workflow
+state pointer. The state machine and execution spec template live in
+[`docs/workflow/agent-workflow.md`](docs/workflow/agent-workflow.md) and
+[`docs/workflow/execution-spec-template.md`](docs/workflow/execution-spec-template.md).
+
+GitHub issues are the public backlog/spec surface when an issue exists. The
+parent workspace's `specs/` directory remains the durable home for local briefs
+that start outside GitHub, and `TASK.md` remains branch-local execution context.
+If both exist, link the branch `TASK.md` back to the issue or workspace spec that
+it implements.
+
 ## Workspace context
 
 This repo lives inside the `emacs-config` workspace folder alongside reference configurations. For the full workspace layout, see `../CLAUDE.md` (one level up, at `emacs-config/CLAUDE.md`).

--- a/docs/workflow/agent-workflow.md
+++ b/docs/workflow/agent-workflow.md
@@ -1,0 +1,87 @@
+# Literate Emacs agent workflow
+
+How issues move through `literate-emacs.d`, who owns each step, and how the
+GitHub labels drive it. This workflow is intentionally lightweight: the durable
+configuration lives in the literate org file, durable local briefs may still
+live in the parent workspace's `specs/` directory, and branch-local execution
+state lives in `TASK.md`.
+
+## Label axes
+
+An ordinary work issue can carry labels from these axes:
+
+| Axis | Select | Meaning |
+| --- | --- | --- |
+| `agent:*` | exactly one | workflow state: what happens next and who owns it |
+| GitHub type labels | usually one | `bug`, `enhancement`, `documentation`, or `question` |
+
+The default GitHub labels remain the type-ish labels for now. Do not introduce a
+custom `type:*` axis until there is enough issue volume to justify it.
+
+## Specs and task files
+
+- GitHub issues are the public backlog/spec surface when an issue exists.
+- Workspace `specs/` remain durable local briefs for exploratory or multi-step
+  Emacs work that starts outside GitHub.
+- `TASK.md` remains branch-local execution context. It should link back to the
+  GitHub issue or workspace spec that it implements, and it should be removed
+  before the branch is merged.
+
+## State machine
+
+```text
+             agent:needs-info <--------------------+
+                    ^                              |
+                    | missing context              |
+                    |                              |
+new issue -> agent:triage -> agent:refine -> agent:ready
+                 |              |              |
+                 | invalid      | spec ready   | Jeff approves
+                 v              v              v
+              closed       waiting gate    agent:implement
+                                                 |
+                                                 | execution error
+                                                 v
+                                           agent:blocked
+```
+
+## States, owners, entry and exit
+
+- `agent:triage` - Triage Agent. Validate that the issue is real and in scope,
+  choose the appropriate type-ish label, and decide whether it is ready to spec.
+  Move to `agent:refine` when clear enough, or `agent:needs-info` when it lacks
+  required context.
+
+- `agent:needs-info` - blocked on Jeff. Any agent can move an issue here when it
+  cannot proceed without missing context. The issue comment must state exactly
+  what is missing. When Jeff answers, move it back to the state that can use the
+  new information, usually `agent:refine`.
+
+- `agent:refine` - Refinement Agent. Write an execution spec into the issue body
+  using `docs/workflow/execution-spec-template.md`. For small documentation-only
+  issues, the spec can be correspondingly small, but it still needs scope,
+  acceptance criteria, and verification.
+
+- `agent:ready` - waiting for Jeff. The spec is complete and ready for approval.
+  Nothing gets implemented merely because a spec exists; approval moves the
+  issue to `agent:implement`.
+
+- `agent:implement` - Coding Agent. Implement the approved spec in a branch or
+  worktree, open a PR to `main`, and link the PR to the issue. If implementation
+  hits a conflict, failing verification, or missing prerequisite, move to
+  `agent:blocked` with the concrete blocker.
+
+- `agent:blocked` - blocked during execution. Needs Jeff or a follow-up issue to
+  unblock. Move back to `agent:implement` once the blocker is resolved.
+
+## Conventions
+
+- Keep exactly one `agent:*` label on each open ordinary work issue.
+- A closed issue carries zero `agent:*` labels. The `agent-label-lifecycle`
+  workflow enforces this on close while leaving archival labels like `bug`,
+  `enhancement`, `documentation`, and `question` in place.
+- The `agent:*` label answers "what happens next?" A closed issue has no next
+  action, so there is no `agent:done` label.
+- The implementation agent must preserve the literate invariant: Emacs Lisp
+  changes go in `jeff-emacs-config.org`, and the matching tangled `init.el` is
+  committed with it.

--- a/docs/workflow/execution-spec-template.md
+++ b/docs/workflow/execution-spec-template.md
@@ -1,0 +1,87 @@
+# Execution spec template
+
+The Refinement Agent writes this into the issue body during `agent:refine`, then
+moves the issue to `agent:ready`. The completed spec is the contract the Coding
+Agent executes against. Keep it concrete: every line should be something an
+executor can act on or a reviewer can check.
+
+---
+
+## Spec
+
+**Summary.** One sentence: what this issue makes true when it is done.
+
+**Why / context.** The problem and the forces. Link the driving GitHub issue,
+workspace spec, prior PR, package manual, or reference config note.
+
+**Scope.**
+
+- In: the bounded set of changes this issue covers.
+- Out: explicitly excluded work, with links to the issue or spec that owns it
+  when applicable.
+
+**Affected paths.** The files or directories this will touch:
+
+- `jeff-emacs-config.org`
+- `init.el`
+- `emacs-cheat-sheet.org`
+- `docs/...`
+
+**Implementation steps.** Ordered and concrete enough to execute without
+re-deriving the design:
+
+1. ...
+2. ...
+3. ...
+
+**Acceptance criteria.** Checkboxes a reviewer can tick:
+
+- [ ] ...
+- [ ] ...
+
+**Verification commands.** Exact commands and manual checks that must pass.
+Paste-able shell commands belong in fenced blocks:
+
+```bash
+just verify-tangle
+git diff --check
+```
+
+For live Emacs checks, prefer keystrokes over command names:
+
+- `C-h f <function>`
+- `C-h v <variable>`
+- `C-h k <key sequence>`
+
+**Risk / rollback.** What can go wrong and how to back out. For configuration
+changes, this is usually reverting the PR and re-tangling. For global Emacs
+state outside this repo, include the exact teardown command or file removal
+instruction.
+
+**Dependencies.** Blocked by `#NNN`; blocks `#NNN`. Link parent workspace specs
+when the issue implements a slice of a broader brief.
+
+---
+
+## Literate config requirements
+
+- `jeff-emacs-config.org` is the source of truth.
+- Do not edit `init.el` by hand. Regenerate it from the org file.
+- Any commit that changes Emacs Lisp in `jeff-emacs-config.org` must include the
+  matching tangled `init.el`.
+- Run `just verify-tangle` for behavior changes that touch the literate config.
+- Docs-only and workflow-only changes that do not touch `jeff-emacs-config.org`
+  or `init.el` do not require `just verify-tangle`; `git diff --check` is enough
+  unless the spec adds another verification step.
+
+## Global Emacs state disclosure
+
+Anything under `~/.emacs.d/` or another non-worktree, non-git-managed Emacs path
+is Jeff-side state. Before a spec asks an agent or Jeff to create, modify,
+remove, install, or regenerate that state, it must name:
+
+- the path,
+- the provenance,
+- the purpose,
+- the teardown path,
+- whether the change needs to be replicated on other machines.


### PR DESCRIPTION
## Summary
- add an issue-close workflow that strips agent:* labels from closed issues
- document the lightweight agent label state machine and execution spec shape
- link CLAUDE.md to the new workflow docs
- create/update the six agent:* labels on GitHub to match lab-infra

## Verification
- git diff --check
- verified agent:* labels via gh label list
- skipped just verify-tangle because this is workflow/docs only and does not touch jeff-emacs-config.org or init.el